### PR TITLE
Feature: caching of evaluations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,13 @@ members = [
   "wasm-accumulo-access",
   "fuzz"
 ]
+
+[profile.release.package.accumulo-access]
+opt-level = 3
+
+[profile.release.package.wasm-accumulo-access]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"
+
+[profile.release.package.accumulo-access-fuzz]
+debug = 1

--- a/accumulo-access/Cargo.toml
+++ b/accumulo-access/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulo-access"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Lars Wilhelmsen <sral-backwards@sral.org>"]
 description = "Rust API for parsing and evaluating Accumulo Access Expressions"
@@ -17,9 +17,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cached = { version = "0.47.0", optional = true, features = ["ahash"] }
+thiserror = "1.0.56"
 
 [dev-dependencies]
 rstest = "0.18.2"
-
-[profile.release]
-opt-level = 3

--- a/accumulo-access/Cargo.toml
+++ b/accumulo-access/Cargo.toml
@@ -8,12 +8,18 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/larsw/accumulo-access-rs"
 readme = "README.md"
 
+[features]
+default = ["caching"]
+caching = ["dep:cached"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+cached = { version = "0.47.0", optional = true, features = ["ahash"] }
+
+[dev-dependencies]
 rstest = "0.18.2"
-# no dependencies!
 
 [profile.release]
 opt-level = 3

--- a/accumulo-access/src/caching.rs
+++ b/accumulo-access/src/caching.rs
@@ -1,0 +1,75 @@
+use cached::{proc_macro::cached, Cached, SizedCache};
+
+#[cached(
+type = "SizedCache<String, Result<bool, super::ParserError>>",
+create = "{ SizedCache::with_size(20000) }",
+convert = r##"{ format!("{}{}", expression, tokens) }"##
+)]
+pub fn check_authorization_csv(
+    expression: String,
+    tokens: String,
+) -> Result<bool, super::ParserError> {
+    super::check_authorization_csv(expression, tokens)
+}
+
+pub fn clear_authz_cache() -> Result<(), String> {
+    let mut cache = crate::caching::CHECK_AUTHORIZATION_CSV
+        .lock()
+        .map_err(|e| format!("Failed to lock cache: {}", e))?;
+    cache.cache_clear();
+    Ok(())
+}
+
+pub struct AuthzCacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub size: usize,
+}
+
+impl AuthzCacheStats {
+    pub fn new(hits: u64, misses: u64, size: usize) -> Self {
+        Self {
+            hits,
+            misses,
+            size,
+        }
+    }
+}
+
+pub fn authz_cache_stats() -> Result<AuthzCacheStats, String> {
+    let cache = crate::caching::CHECK_AUTHORIZATION_CSV
+        .lock()
+        .map_err(|e| format!("Failed to lock cache: {}", e))?;
+
+    Ok(AuthzCacheStats::new(cache.cache_hits().unwrap(), cache.cache_misses().unwrap(), cache.cache_size()))
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use rstest::rstest;
+
+//     #[rstest]
+//     #[case("label1", "label1", true)]
+//     #[case("label1|label2", "label1", true)]
+//     #[case("label1&label2", "label1", false)]
+//     #[case("label1&label2", "label1,label2", true)]
+//     #[case("label1&(label2 | label3)", "label1", false)]
+//     #[case("label1&(label2 | label3)", "label1,label3", true)]
+//     #[case("label1&(label2 | label3)", "label1,label2", true)]
+//     #[case("(label2 | label3)", "label1", false)]
+//     #[case("(label2 | label3)", "label2", true)]
+//     #[case("(label2 & label3)", "label2", false)]
+//     #[case("((label2 | label3))", "label2", true)]
+//     #[case("((label2 & label3))", "label2", false)]
+//     #[case("(((((label2 & label3)))))", "label2", false)]
+//     fn test_check_authorization(
+//         #[case] expr: impl AsRef<str>,
+//         #[case] authorized_tokens: impl AsRef<str>,
+//         #[case] expected: bool,
+//     ) {
+//         let result =
+//             check_authorization_csv(expr.as_ref(), authorized_tokens.as_ref()).unwrap();
+//         assert_eq!(result, expected);
+//     }
+// }

--- a/accumulo-access/src/lexer.rs
+++ b/accumulo-access/src/lexer.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT or Apache-2.0 license that can be found in the LICENSE-MIT or LICENSE-APACHE files.
 
 use std::fmt::Display;
+use thiserror::Error;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Token {
@@ -32,7 +33,7 @@ pub struct Lexer<'a> {
     position: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Clone)]
 pub enum LexerError {
     UnexpectedCharacter(char, usize),
 }

--- a/accumulo-access/src/lib.rs
+++ b/accumulo-access/src/lib.rs
@@ -50,6 +50,15 @@ pub fn check_authorization(expression: &str, tokens: &Vec<String>) -> Result<boo
     Ok(result)
 }
 
+#[cfg(feature = "caching")]
+mod caching {
+    use cached::*;
+
+    pub fn check_authorization(expression: &str, tokens: &Vec<String>) -> Result<bool, super::ParserError> {
+        super::check_authorization(expression, tokens)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/accumulo-access/src/lib.rs
+++ b/accumulo-access/src/lib.rs
@@ -3,6 +3,8 @@
 
 mod lexer;
 mod parser;
+#[cfg(feature = "caching")]
+pub mod caching;
 
 pub use crate::lexer::Lexer;
 pub use crate::parser::Parser;
@@ -50,19 +52,18 @@ pub fn check_authorization(expression: &str, tokens: &Vec<String>) -> Result<boo
     Ok(result)
 }
 
-#[cfg(feature = "caching")]
-mod caching {
-    use cached::*;
-
-    pub fn check_authorization(expression: &str, tokens: &Vec<String>) -> Result<bool, super::ParserError> {
-        super::check_authorization(expression, tokens)
-    }
+pub fn check_authorization_csv<'a>(
+    expression: String,
+    tokens: String,
+) -> Result<bool, ParserError> {
+    let tokens: Vec<String> = tokens.split(',').map(|s| s.to_string()).collect();
+    check_authorization(expression.as_str(), &tokens)
 }
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
     use super::*;
+    use rstest::rstest;
 
     #[rstest]
     #[case("label1", "label1", true)]
@@ -78,8 +79,13 @@ mod tests {
     #[case("((label2 | label3))", "label2", true)]
     #[case("((label2 & label3))", "label2", false)]
     #[case("(((((label2 & label3)))))", "label2", false)]
-    fn test_check_authorization(#[case] expr: impl AsRef<str>, #[case] authorized_tokens: impl AsRef<str>, #[case] expected: bool) {
-        let authorized_tokens: Vec<String> = authorized_tokens.as_ref()
+    fn test_check_authorization(
+        #[case] expr: impl AsRef<str>,
+        #[case] authorized_tokens: impl AsRef<str>,
+        #[case] expected: bool,
+    ) {
+        let authorized_tokens: Vec<String> = authorized_tokens
+            .as_ref()
             .to_owned()
             .split(',')
             .map(|s| s.to_string())

--- a/accumulo-access/src/parser.rs
+++ b/accumulo-access/src/parser.rs
@@ -5,9 +5,10 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use crate::lexer::{Lexer, Token};
 use crate::ParserError::LexerError;
+use thiserror::Error;
 
 /// `ParserError` is returned when the parser encounters an error.
-#[derive(Debug)]
+#[derive(Error, Debug, PartialEq, Clone)]
 pub enum ParserError {
     /// The scope (top-level or set of parentheses) is empty.
     EmptyScope,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,13 +13,6 @@ libfuzzer-sys = "0.4"
 [dependencies.accumulo-access]
 path = "../accumulo-access"
 
-# Prevent this from interfering with workspaces
-#[workspace]
-#members = ["."]
-
-[profile.release]
-debug = 1
-
 [[bin]]
 name = "fuzz_target_1"
 path = "fuzz_targets/fuzz_target_1.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,187 @@
+use std::collections::HashSet;
+
+use pest::{iterators::Pair, Parser};
+use pest_derive::Parser;
+
+#[derive(Debug, PartialEq)]
+pub enum AuthorizationExpression {
+    And(Vec<AuthorizationExpression>),
+    Or(Vec<AuthorizationExpression>),
+    AccessToken(String),
+}
+
+impl AuthorizationExpression {
+    pub fn and(expressions: Vec<AuthorizationExpression>) -> AuthorizationExpression {
+        AuthorizationExpression::And(expressions)
+    }
+
+    pub fn or(expressions: Vec<AuthorizationExpression>) -> AuthorizationExpression {
+        AuthorizationExpression::Or(expressions)
+    }
+
+    pub fn access_token(token: String) -> AuthorizationExpression {
+        AuthorizationExpression::AccessToken(token)
+    }
+
+    pub fn evaluate(
+        expr: &AuthorizationExpression,
+        authorizations: &Authorizations,
+    ) -> Result<bool, String> {
+        match expr {
+            AuthorizationExpression::And(expressions) => Ok(expressions
+                .iter()
+                .all(|expr| AuthorizationExpression::evaluate(expr, authorizations).unwrap())),
+            AuthorizationExpression::Or(expressions) => Ok(expressions
+                .iter()
+                .any(|expr| AuthorizationExpression::evaluate(expr, authorizations).unwrap())),
+            AuthorizationExpression::AccessToken(value) => {
+                Ok(authorizations.is_authorized_for(value))
+            }
+        }
+    }
+}
+
+#[derive(Parser)]
+#[grammar = "grammar.pest"]
+struct AccessExpressionParser;
+
+// a function that parses a string With Rule::access_expression and transforms it into a tree of AuthorizationExpression.
+pub fn parse_expr(expr: &str) -> Result<AuthorizationExpression, String> {
+    let mut pairs = AccessExpressionParser::parse(Rule::access_expression, expr)
+        .map_err(|e| format!("Error parsing expression: {}", e))?;
+
+    let access_expression = pairs.next().unwrap();
+
+    println!("Parsed expression: {:?}", access_expression);
+
+    fn parse_(pair: Pair<Rule>) -> AuthorizationExpression {
+        match pair.as_rule() {
+            Rule::access_expression => {
+                parse_(pair.into_inner().next().unwrap()) 
+            },
+            Rule::and_expression => {
+                let mut expressions = vec![];
+                for inner in pair.into_inner() {
+                    expressions.push(parse_(inner));
+                }
+                AuthorizationExpression::And(expressions)
+            }
+            Rule::or_expression => {
+                let mut expressions = vec![];
+                for inner in pair.into_inner() {
+                    expressions.push(parse_(inner));
+                }
+                AuthorizationExpression::Or(expressions)
+            }
+            Rule::access_token => {
+                AuthorizationExpression::AccessToken(pair.as_str().to_string())
+            },
+            _ => unreachable!(),
+        }
+    }
+    Ok(parse_(access_expression))
+}
+
+// pub fn parse_expr(expr: &str) -> Result<AuthorizationExpression, String> {
+//     let mut pairs = AccessExpressionParser::parse(Rule::access_expression, expr)
+//         .map_err(|e| format!("Error parsing expression: {}", e))?;
+
+//     // print pairs nicely:
+//     for pair in pairs.clone() {
+//         display_pair(pair, 0);
+//         println!();
+//     }
+//     let access_expression = pairs.next().unwrap();
+
+//     println!("Parsed expression: {:?}", access_expression);
+
+//     fn parse_(pair: Pair<Rule>) -> AuthorizationExpression {
+//         match pair.as_rule() {
+//             Rule::access_expression => parse_(pair.into_inner().next().unwrap()),
+//             Rule::and_expression => {
+//                 let mut expressions = vec![];
+//                 for inner in pair.into_inner() {
+//                     expressions.push(parse_(inner));
+//                 }
+//                 AuthorizationExpression::And(expressions)
+//             }
+//             Rule::or_expression => {
+//                 let mut expressions = vec![];
+//                 for inner in pair.into_inner() {
+//                     expressions.push(parse_(inner));
+//                 }
+//                 AuthorizationExpression::Or(expressions)
+//             }
+//             Rule::access_token => AuthorizationExpression::AccessToken(pair.as_str().to_string()),
+//             _ => unreachable!(),
+//         }
+//     }
+//     Ok(parse_(access_expression))
+// }
+
+pub struct Authorizations {
+    values: HashSet<String>,
+}
+
+impl Authorizations {
+    pub fn new(values: &[&str]) -> Authorizations {
+        Authorizations {
+            values: values.iter().map(|v| v.to_string()).collect(),
+        }
+    }
+
+    pub fn is_authorized_for(&self, value: &str) -> bool {
+        self.values.contains(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn parse_and_evaluate() -> Result<(), String> {
+        let expression = "label1 & label2 & label3";
+
+        let authorizations = Authorizations::new(&["label1", "label2", "label3"]);
+
+        let parsed_expr = parse_expr(expression)?;
+        let result = AuthorizationExpression::evaluate(&parsed_expr, &authorizations)?;
+        assert_eq!(result, true);
+        println!("Evaluation result: {}", result);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_and_evaluate_false() -> Result<(), String> {
+        let expression = "label1 & label2 & label3";
+
+        let authorizations = Authorizations::new(&["label2", "label3"]);
+
+        let parsed_expr = parse_expr(expression)?;
+        let result = AuthorizationExpression::evaluate(&parsed_expr, &authorizations)?;
+        assert_eq!(result, false);
+        println!("Evaluation result: {}", result);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case("label1 & label2 & label3", &["label2", "label3"], false)]
+    #[case("label1 & label2 & label3", &["label2", "label3", "label1"], true)]
+    #[case("label1 & (label2 | label3)", &["label1", "label3"], true)]
+    #[case("label1 & (label2 | label3)", &["label1"], false)]
+    #[case("label1 | ((label2))", &["label2"], true)]
+    fn parse_and_evaluate_parameterized(
+        #[case] expression: &str,
+        #[case] labels: &[&str],
+        #[case] expected: bool,
+    ) -> Result<(), String> {
+        let authorizations = Authorizations::new(labels);
+        let parsed_expr = parse_expr(expression)?;
+        let result = AuthorizationExpression::evaluate(&parsed_expr, &authorizations)?;
+        assert_eq!(result, expected);
+        Ok(())
+    }
+}

--- a/wasm-accumulo-access/Cargo.toml
+++ b/wasm-accumulo-access/Cargo.toml
@@ -19,7 +19,3 @@ js-sys = { version = "0.3.66", features = [] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"


### PR DESCRIPTION
Uses a `SizedCache<>` from the `cached` crate for memoization/caching.
Right now, the cache size is hard-coded to 20000.